### PR TITLE
Added a `rating` column to the `segmentations` table

### DIFF
--- a/src/streetscapes/project.py
+++ b/src/streetscapes/project.py
@@ -45,6 +45,7 @@ class Project:
                 "curated": "BOOL NOT NULL DEFAULT FALSE",
                 "image": "UUID NOT NULL",
                 "labels": "STRING[]",
+                "rating": "INTEGER",  # 0-5
                 "polygons": "GEOMETRY",
             },
             "init": [
@@ -464,6 +465,7 @@ class Project:
         image: uuid.UUID | str,
         labels: list[str],
         curated: bool = False,
+        rating: int | None = None,
         polygons: shp.GeometryCollection | None = None,
         overwrite: bool = False,
     ):
@@ -474,6 +476,7 @@ class Project:
             image: Image ID.
             labels: A list of labels.
             curated: Curation status.
+            rating: Segmentation rating.
             polygons: A Shapely GeometryCollection.
             overwrite: Replace or ignore conflicting data.
         """
@@ -483,6 +486,7 @@ class Project:
             "curated": [curated],
             "image": [ibis.uuid(image).to_pyarrow()],
             "labels": [labels],
+            "rating": [rating],
             "polygons": [polygons],
         }
 


### PR DESCRIPTION
Note: inserting segmentations into an existing database will fail. 

***Only for testing purposes***: The easiest way to test this would be to drop the `segmentations` table and run one of the segmentation models from the CLI. The table will be regenerated automatically with the new schema.