### PR TITLE
Various small fixes

### DIFF
--- a/src/streetscapes/models/sam3/model.py
+++ b/src/streetscapes/models/sam3/model.py
@@ -104,18 +104,23 @@ class SAM3:
             result = self.model(text=_prompt)[0]
 
             # Process the model outputs
-            masks = result.masks.data.cpu().numpy().squeeze()
+            # `result.masks` is `None` when no instances match the prompt.
+            if result.masks is None:
+                instance_labels = []
+                instances = np.zeros((0, *image.shape[:2]), dtype=np.bool_)
+            else:
+                masks = result.masks.data.cpu().numpy()
 
-            # Instance labels extracted from the class IDs
-            instance_labels = [result.names[int(c)] for c in result.boxes.cls]
+                # Instance labels extracted from the class IDs
+                instance_labels = [result.names[int(c)] for c in result.boxes.cls]
 
-            # Populate the instance masks.
-            instances = np.zeros(
-                (len(instance_labels), *image.shape[:2]),
-                dtype=np.bool_,
-            )
-            for mask_idx, sam_mask in enumerate(masks):
-                instances[mask_idx][sam_mask > 0] = True
+                # Populate the instance masks.
+                instances = np.zeros(
+                    (len(instance_labels), *image.shape[:2]),
+                    dtype=np.bool_,
+                )
+                for mask_idx, sam_mask in enumerate(masks):
+                    instances[mask_idx][sam_mask > 0] = True
 
             # Extract and store the segmentations.
             segmentation["labels"] = instance_labels

--- a/src/streetscapes/project.py
+++ b/src/streetscapes/project.py
@@ -688,13 +688,14 @@ class Project:
     def ingest_mapillary(self, df: DataFrame, table: str = "mapillary"):
         """Ingest a DataFrame of Mapillary metadata."""
         # Ensure that that the camera_parameters column is a list of floats
-        df["camera_parameters"] = df["camera_parameters"].apply(
-            lambda params: (
-                [float(params)]
-                if isinstance(params, int | float)
-                else list(map(float, params))
+        if df.get("camera_parameters") is not None:
+            df["camera_parameters"] = df["camera_parameters"].apply(
+                lambda params: (
+                    [float(params)]
+                    if isinstance(params, int | float)
+                    else list(map(float, params))
+                )
             )
-        )
 
         df.insert(loc=0, column="uuid", value=None)
 
@@ -711,7 +712,14 @@ class Project:
 
         # TODO: consider configurable duplicate behaviour (REPLACE or IGNORE)
         # TODO do not depend of order in df columns, but used named columns in SQL query
-        self._con.raw_sql(f"INSERT OR IGNORE INTO {table} FROM metadata_tile")
+        try:
+            self._con.raw_sql(f"INSERT OR IGNORE INTO {table} FROM metadata_tile")
+        except Exception as err:
+            if "Conversion Error" in str(err):
+                logger.error("Failed to insert data into table.")
+                logger.error(str(err))
+            else:
+                raise err
 
     def ingest_image_records(self, records: list[dict]):
         """Batch insert local images into `images`.

--- a/src/streetscapes/utils/functions.py
+++ b/src/streetscapes/utils/functions.py
@@ -428,9 +428,6 @@ def extract_categories(
     prompt = prompt.strip().lower()
 
     prompt = ".".join(
-        [cat.strip() for cat in prompt.split(" ") if len(cat.strip()) > 0]
-    )
-    prompt = ".".join(
         [cat.strip() for cat in prompt.split(",") if len(cat.strip()) > 0]
     )
     prompt = ". ".join(


### PR DESCRIPTION
- mapillary fetch-metadata could fail. Patched now, proper fix is described in #181 
- SAM3 segmentation could fail if no instances were found matching the prompt
- `--prompt "red wall, blue sky"` would be converted to `["red", "wall", "blue", "sky"]` before being passed to a segmentation model. Will now return `["red wall", "blue sky"]` to allow for more complex instance detection in SAM3.