### PR TITLE
Remove Maskformer labels argument

### DIFF
--- a/docs/tutorial/cli.md
+++ b/docs/tutorial/cli.md
@@ -102,7 +102,7 @@ Download Mapillary images to a local directory.
 │ --token               Mapillary OAuth token (if not set via                  │
 │                       MAPILLARY_TOKEN).                                      │
 │ --project             An optional project to attach to.                      │
-╰────────────────────────────────────────────────────────────────────────────────╯
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Segmenting images
@@ -146,7 +146,6 @@ Segment images with MaskFormer.
 ╭─ Parameters ─────────────────────────────────────────────────────────────────╮
 │ --image-path             Path to the images to be segmented. If not provided │
 │                          uses all downloaded images in the project.          │
-│ --labels --empty-labels  Labels to focus on.                                 │
 │ --batch-size             Batch size for the segmentation model. [default:    │
 │                          10]                                                 │
 │ --model-id               Mask2Former model to load. [default:                │
@@ -160,7 +159,7 @@ Segment images with MaskFormer.
 │                          small disconnected parts within each binary         │
 │                          instance mask. [default: 0.8]                       │
 │ --fuse-labels            The labels in this state will have all their        │
-│   --empty-fuse-labels    instances fused together.                          │
+│   --empty-fuse-labels    instances fused together.                           │
 │ --run                    Model run ID. Will be generated automatically if    │
 │                          not provided.                                       │
 │ --project                The project to use. Uses the active project by      │
@@ -168,7 +167,7 @@ Segment images with MaskFormer.
 │ --overwrite              Overwrite an existing run. [default: False]         │
 │ --verbose                Print verbose log to the terminal. Useful for       │
 │                          debugging models. [default: False]                  │
-╰────────────────────────────────────────────────────────────────────────────────╯
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 By default, all images in the current streetscapes project will be segmented. These will be processed in batches whose size can be specified with the `batch_size` option (the default is `10`) depending on your hardware it can be better to make that number smaller (laptop) or larger (HPC with GPU). You can also specify a (comma-separated) list of labels (categories of objects) that the model should focus on. By default, if the `--labels` argument is not provided, the model will try to find objects corresponding to ***all*** the categories that it can recognise.

--- a/docs/tutorial/cli.md
+++ b/docs/tutorial/cli.md
@@ -170,7 +170,7 @@ Segment images with MaskFormer.
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
-By default, all images in the current streetscapes project will be segmented. These will be processed in batches whose size can be specified with the `batch_size` option (the default is `10`) depending on your hardware it can be better to make that number smaller (laptop) or larger (HPC with GPU). You can also specify a (comma-separated) list of labels (categories of objects) that the model should focus on. By default, if the `--labels` argument is not provided, the model will try to find objects corresponding to ***all*** the categories that it can recognise.
+By default, all images in the current streetscapes project will be segmented. These will be processed in batches whose size can be specified with the `batch_size` option (the default is `10`) depending on your hardware it can be better to make that number smaller (laptop) or larger (HPC with GPU).
 
 For instance, assuming that you have downloaded images for the current project, use the following command to start segmentation:
 

--- a/src/streetscapes/models/maskformer/cli.py
+++ b/src/streetscapes/models/maskformer/cli.py
@@ -9,7 +9,6 @@ from cyclopts import Parameter
 from ray import cloudpickle
 
 from streetscapes import CFG, utils
-from streetscapes.models.maskformer.model import MaskFormer
 from streetscapes.project import Project
 from streetscapes.serve.server import serve_model
 from streetscapes.utils import logger
@@ -19,7 +18,6 @@ from streetscapes.utils.masks import mask2poly
 def cli(
     *,
     image_path: str | None = None,
-    labels: list[str] | None = None,
     batch_size: int = 10,
     model_id: str = "facebook/mask2former-swin-large-mapillary-vistas-panoptic",
     threshold: float = 0.5,
@@ -36,7 +34,6 @@ def cli(
     Args:
         image_path: Path to the images to be segmented. If not provided uses all
             downloaded images in the project.
-        labels: Labels to focus on.
         batch_size: Batch size for the segmentation model.
         model_id: Mask2Former model to load.
         threshold: The probability score threshold to keep predicted instance masks.
@@ -85,9 +82,6 @@ def cli(
         logger.info("Nothing to process.")
         return
 
-    if labels is None:
-        labels = list(MaskFormer.id_to_label.values())
-
     handle = serve_model(model, verbose, **model_params)
     logger.info(f"Segmenting {len(unprocessed)} images using {model}...")
     batches = list(batched(unprocessed, batch_size))
@@ -95,7 +89,6 @@ def cli(
         # Extract the paths and open the images as NumPy arrays.
         request = {
             "images": [],
-            "labels": labels,
         }
         for uid in batch:
             path, _ = unprocessed[uid]

--- a/src/streetscapes/models/maskformer/cli.py
+++ b/src/streetscapes/models/maskformer/cli.py
@@ -1,7 +1,7 @@
 """MaskFormer CLI."""
 
 from itertools import batched
-from typing import Annotated, cast
+from typing import Annotated, Any, cast
 
 import imageio as iio
 import numpy as np
@@ -87,7 +87,7 @@ def cli(
     batches = list(batched(unprocessed, batch_size))
     for batch_idx, batch in enumerate(batches, 1):
         # Extract the paths and open the images as NumPy arrays.
-        request = {
+        request: dict[str, Any] = {
             "images": [],
         }
         for uid in batch:

--- a/src/streetscapes/models/maskformer/model.py
+++ b/src/streetscapes/models/maskformer/model.py
@@ -161,7 +161,6 @@ class MaskFormer:
         self,
         uids: list[uuid.UUID],
         images: list[np.ndarray],
-        labels: str | list[str] | None = None,
     ) -> list[dict]:
         """Segment the provided sequence of images.
 
@@ -170,7 +169,6 @@ class MaskFormer:
                 This is used for keeping track of which images have been segmented,
                 regardless of the file name and where they are stored.
             images: A list (batch) of images as NumPy arrays.
-            labels: A list of labels (object categories).
 
         Returns:
             A list of dictionaries containing instance-level segmentation information.
@@ -178,14 +176,6 @@ class MaskFormer:
         """
         import torch
 
-        if labels is None:
-            labels = list(MaskFormer.id_to_label.values())
-
-        # Flatten the label list
-        labels = utils.extract_categories(labels)
-
-        # Eliminate labels that are not recognised by the model
-        labels = list(set(labels).intersection(MaskFormer.id_to_label))
         segmentations = []
 
         with torch.no_grad():

--- a/src/streetscapes/models/maskformer/service.py
+++ b/src/streetscapes/models/maskformer/service.py
@@ -15,7 +15,6 @@ class MaskFormerImage(BaseModel):
 
 class MaskFormerRequest(BaseModel):
     images: list[MaskFormerImage]
-    labels: list[str]
 
 
 class MaskFormerResponse(BaseModel):
@@ -65,7 +64,6 @@ class MaskFormerService:
         segmentations = self.model.segment_images(
             uids,
             images,
-            schema.labels,
         )
 
         # Construct the response


### PR DESCRIPTION
Closes #113 

Passing labels:

- did not work
- was not clear to me what the use-case is (extra labels don't really hurt...)
- was fragile (users need to know what the possible labels are, can't enter a free form prompt
- didn't see how to clearly fix it

So I removed the (broken) functionality