### PR TITLE
Add panoramax, fix tiling bug

### DIFF
--- a/docs/tutorial/cli.md
+++ b/docs/tutorial/cli.md
@@ -54,7 +54,7 @@ The `project_dir` directory is where Streetscapes will be storing its projects, 
 
 ## Downloading images
 
-The Streetscapes CLI supports downloading images from [Mapillary](https://www.mapillary.com/) and [KartaView](https://kartaview.org/landing) (the [Amsterdam](https://api.data.amsterdam.nl/) collection is currently not yet supported). Both follow the same two steps — fetch the metadata for a bounding box, then download the images it describes. The available options can be displayed with the `--help` option via the subcommand for each source:
+The Streetscapes CLI supports downloading images from [Mapillary](https://www.mapillary.com/), [KartaView](https://kartaview.org/landing) and [Panoramax](https://panoramax.fr/) (the [Amsterdam](https://api.data.amsterdam.nl/) collection is currently not yet supported). All three follow the same two steps — fetch the metadata for a bounding box, then download the images it describes. The available options can be displayed with the `--help` option via the subcommand for each source:
 
 ### Mapillary
 
@@ -142,6 +142,62 @@ KartaView serves its images at full resolution, which for recent cameras means 4
 Segmenting those needs a correspondingly large amount of memory, because the models
 scale their masks back up to the size of the image they were given — so on a machine
 with limited RAM, segment KartaView images in small batches (`--batch-size 1`).
+
+### Panoramax
+
+Panoramax is federated: rather than one central server, it is a network of
+instances that each host their own pictures. Streetscapes queries the
+[federated catalogue](https://docs.panoramax.fr/federated-catalog/) by default,
+which indexes every instance taking part. Pass `--instance` to search just one
+instance, or one that is not federated:
+
+```bash
+streetscapes fetch-metadata panoramax 2.34 48.856 2.345 48.86 \
+    --instance https://panoramax.openstreetmap.fr
+```
+
+No token is needed for downloading the images.
+As for Mapillary, the bounding box is split into tiles and
+`--tile-limit` caps the images fetched per tile — but Panoramax returns up to
+32767 images per request against Mapillary's ~2000, so its tiles can be far
+larger before running into problems.
+
+```bash
+streetscapes fetch-metadata panoramax --help
+```
+
+```bash
+Usage: streetscapes fetch-metadata panoramax [OPTIONS] BBOX
+
+Fetch metadata from the Panoramax API.
+
+Queries the federated catalogue by default, which indexes every Panoramax instance
+taking part in the federation, so one query covers them all. Pass --instance to
+search a single instance instead.
+
+The API returns no more than 32767 images per request and offers no paging, so the
+bounding box is split into tiles, as it is for Mapillary. Panoramax tiles can be
+much larger than Mapillary's, as its limit is far higher.
+
+╭─ Arguments ────────────────────────────────────────────────────────────────────╮
+│ *  BBOX  Bounding box (WEST SOUTH EAST NORTH). [required]                      │
+╰────────────────────────────────────────────────────────────────────────────────╯
+╭─ Parameters ───────────────────────────────────────────────────────────────────╮
+│ --tile-size   Tile size in degrees. [default: 0.05]                            │
+│ --tile-limit  Maximum number of images per tile (at most 32767, which is also  │
+│               what 0 means: the most the API will return). [default: 1000]     │
+│ --instance    A single Panoramax instance to query, such as                    │
+│               'https://panoramax.openstreetmap.fr'. Defaults to the federated  │
+│               catalogue.                                                       │
+│ --project     An optional project to attach to.                                │
+╰────────────────────────────────────────────────────────────────────────────────╯
+```
+
+Downloading is straightforward with the following command:
+
+```bash
+streetscapes download-images panoramax
+```
 
 ## Segmenting images
 

--- a/src/streetscapes/cli/download_images.py
+++ b/src/streetscapes/cli/download_images.py
@@ -33,7 +33,7 @@ class SourceClient(Protocol):
         self,
         url: str,
         output_dir: str | Path,
-        image_id: int | None,
+        image_id: int | str | None,
         uid: "uuid.UUID | None" = None,
         skip_existing: bool = True,
     ) -> "ImageMeta":
@@ -50,7 +50,7 @@ def _validate_uuid(uid: str, output_dir: Path) -> bool:
 
 def _existing_img_valid(
     uid: str | None,
-    image_id: int | None,
+    image_id: int | str | None,
     output_dir: Path,
     skip_existing: bool,
 ) -> bool:
@@ -135,8 +135,9 @@ def _download_images(
 
         image_data.append(_format_image(uid, source, shard, tags=tags))
 
-        # Update the source table
-        proj._con.raw_sql(f"UPDATE {source} SET image='{uid}' WHERE id={image_id};")
+        # Update the source table. The ID is quoted because Panoramax identifies
+        # its pictures by UUID; the numeric IDs of the other sources still cast.
+        proj._con.raw_sql(f"UPDATE {source} SET image='{uid}' WHERE id='{image_id}';")
 
         downloaded += 1
 
@@ -218,3 +219,33 @@ def kartaview(
         return
 
     _download_images(proj, KartaViewClient(), "kartaview", records, skip_existing)
+
+
+@download_images_cli.command(name="panoramax")
+def panoramax(
+    *,
+    skip_existing: bool = True,
+    project: str | None = None,
+):
+    """Download Panoramax images to a local directory.
+
+    Images are downloaded from the instance hosting them, which is recorded when
+    the metadata is fetched, so no instance needs to be given here.
+
+    Args:
+        skip_existing: If true, only download missing images; otherwise overwrite.
+        project: An optional project to attach to.
+    """
+    from streetscapes.project import Project
+    from streetscapes.sources.panoramax import PanoramaxClient
+
+    proj = Project(project or CFG.active_project)
+    _show_project(proj)
+
+    records = proj.get_download_records("panoramax", "image_url", skip_existing)
+
+    if not records:
+        logger.info("No new images to download.")
+        return
+
+    _download_images(proj, PanoramaxClient(), "panoramax", records, skip_existing)

--- a/src/streetscapes/cli/fetch_metadata.py
+++ b/src/streetscapes/cli/fetch_metadata.py
@@ -109,6 +109,67 @@ def kartaview(
     _report(proj, "kartaview", bbox)
 
 
+@fetch_metadata_cli.command(name="panoramax")
+def panoramax(
+    bbox: Bbox,
+    /,
+    *,
+    tile_size: float = 0.05,
+    tile_limit: int = 1000,
+    instance: str | None = None,
+    project: str | None = None,
+):
+    """Fetch metadata from the Panoramax API.
+
+    Queries the federated catalogue by default, which indexes every Panoramax
+    instance taking part in the federation, so one query covers them all. Pass
+    `--instance` to search a single instance instead.
+
+    The API returns no more than 32767 images per request and offers no paging,
+    so the bounding box is split into tiles, as it is for Mapillary. Panoramax
+    tiles can be much larger than Mapillary's, as its limit is far higher.
+
+    Args:
+        bbox: Bounding box (WEST SOUTH EAST NORTH).
+        tile_size: Tile size in degrees.
+        tile_limit: Maximum number of images per tile (at most 32767, which is
+            also what 0 means: the most the API will return).
+        instance: A single Panoramax instance to query, such as
+            'https://panoramax.openstreetmap.fr'. Defaults to the federated
+            catalogue.
+        project: An optional project to attach to.
+    """
+    from streetscapes.project import Project
+    from streetscapes.sources.panoramax import (
+        FEDERATED_CATALOGUE,
+        PanoramaxClient,
+        PanoramaxError,
+    )
+
+    logger.info(f"Fetching metadata for {bbox=}")
+
+    client = PanoramaxClient(instance or FEDERATED_CATALOGUE)
+    proj = Project(project)
+
+    ntiles, tiles = split_bbox(bbox, tile_size)
+    logger.info(f"Splitting bbox in {ntiles} tiles with {tile_size=}")
+    try:
+        for tile, _tile_id in track(
+            tiles, description="Fetching tiles", total=ntiles, console=console
+        ):
+            df = client.fetch_metadata_bbox(tile, tile_limit)
+
+            if len(df) == 0:
+                continue
+
+            proj.ingest_metadata(df, "panoramax")
+    except PanoramaxError as err:
+        logger.error(str(err))
+        raise SystemExit(1) from err
+
+    _report(proj, "panoramax", bbox)
+
+
 def _report(proj: "Project", table: str, bbox: Bbox):
     """Show the user what ended up in the table for the requested bounding box."""
     import ibis

--- a/src/streetscapes/project.py
+++ b/src/streetscapes/project.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from streetscapes.utils.geo import Bbox
 
 
-SOURCE_TABLES = ("mapillary", "kartaview", "local")
+SOURCE_TABLES = ("mapillary", "kartaview", "panoramax", "local")
 
 
 def _format_image(
@@ -151,6 +151,35 @@ class Project:
                 "thumb_url": "STRING",
                 "uploaded_at": "TIMESTAMPTZ",
                 "way_id": "UBIGINT",
+            },
+            "init": [],
+        },
+        "panoramax": {
+            "schema": {
+                "image": "UUID",
+                # Panoramax reports no altitude; the column is kept for consistency
+                "altitude": "FLOAT8",
+                "captured_at": "TIMESTAMPTZ",
+                "compass_angle": "FLOAT8",
+                "creator": "JSON",
+                "field_of_view": "FLOAT8",
+                "geometry": "GEOMETRY",
+                "gps_accuracy": "FLOAT8",
+                "width": "UBIGINT",
+                "height": "UBIGINT",
+                # Panoramax identifies its pictures by UUID rather than by number
+                "id": "UUID PRIMARY KEY",
+                "image_url": "STRING",
+                # The instance hosting the picture, which the federated
+                # catalogue draws from.
+                "instance": "STRING",
+                "is_pano": "BOOL",
+                "license": "STRING",
+                "sequence": "STRING",
+                "sequence_index": "UBIGINT",
+                "thumb_large_url": "STRING",
+                "thumb_url": "STRING",
+                "uploaded_at": "TIMESTAMPTZ",
             },
             "init": [],
         },

--- a/src/streetscapes/sources/README.md
+++ b/src/streetscapes/sources/README.md
@@ -49,6 +49,31 @@ No token is required. Metadata is collected in two steps, as no single public
 endpoint both covers a bounding box and returns complete records: the photos in
 the box are listed first, then their full records are fetched in batches by ID.
 
+### Panoramax
+
+```bash
+streetscapes fetch-metadata panoramax \
+    W S E N \
+    --tile-size 0.05 \
+    --tile-limit 1000 \
+    --instance https://panoramax.openstreetmap.fr
+```
+
+* `bbox`: Bounding box `[west, south, east, north]` to fetch images from.
+* `tile-size`: Tiling of the bounding box, in degrees (default 0.05°). Tiles can
+  be much larger than Mapillary's, as Panoramax returns far more per request.
+* `tile-limit`: Maximum number of images per tile, at most 32767 — which is also
+  what `0` means, the most the API will return.
+* `instance`: A single Panoramax instance to query. Optional — defaults to the
+  federated catalogue.
+
+No token is required. Panoramax is a federation of instances rather than one
+server, so by default the [federated catalogue](https://docs.panoramax.fr/federated-catalog/)
+at `https://api.panoramax.xyz` is queried, which indexes every participating
+instance; `--instance` restricts the search to one of them, or reaches one that is
+not federated. The search endpoint is STAC and offers no paging, so 32767 images is
+the most one request can yield; a fetch that hits the limit says so.
+
 ### Amsterdam Panorama
 
 ```bash
@@ -93,6 +118,19 @@ streetscapes download-images kartaview \
 
 Images are downloaded at full resolution, which for recent cameras means 4K.
 
+### Panoramax
+
+```bash
+streetscapes download-images panoramax \
+    --skip-existing
+```
+
+* `skip-existing`: Only download the images that are missing.
+
+No instance is given here: each picture is downloaded from whichever instance
+hosts it, which is recorded in the `instance` column when the metadata is fetched.
+Much of Panoramax is 360° imagery at up to 8000×4000.
+
 ### Amsterdam Panorama
 
 ```bash
@@ -110,7 +148,7 @@ streetscapes download-images amsterdam \
 
 ## Implementation Notes
 
-* **Sources**: Raw sources (Mapillary, KartaView) and derived datasets (e.g., global streetscapes metadata) implement `fetch_metadata` and provide a standardized manifest writer.
+* **Sources**: Raw sources (Mapillary, KartaView, Panoramax) and derived datasets (e.g., global streetscapes metadata) implement `fetch_metadata` and provide a standardized manifest writer.
 * **Manifest Writer**: `PyArrowGeoParquetWriter` ensures output manifests are compatible with spatial operations.
 * **Transparency**: Each CLI call is fully self-contained; there are no hidden global states or complicated initialization chains.
 * **Extensible**: New sources can be added by implementing `fetch_metadata` and optionally a downloader. The CLI can then expose them as a separate subcommand.

--- a/src/streetscapes/sources/kartaview.py
+++ b/src/streetscapes/sources/kartaview.py
@@ -248,7 +248,7 @@ class KartaViewClient:
         self,
         url: str,
         output_dir: str | Path,
-        image_id: int | None,
+        image_id: int | str | None,
         uid: uuid.UUID | None = None,
         skip_existing: bool = True,
     ) -> ImageMeta:

--- a/src/streetscapes/sources/mapillary.py
+++ b/src/streetscapes/sources/mapillary.py
@@ -180,7 +180,7 @@ class MapillaryClient:
         self,
         url: str,
         output_dir: str | Path,
-        image_id: int | None,
+        image_id: int | str | None,
         uid: uuid.UUID | None = None,
         skip_existing: bool = True,
     ) -> ImageMeta:

--- a/src/streetscapes/sources/panoramax.py
+++ b/src/streetscapes/sources/panoramax.py
@@ -356,7 +356,8 @@ class PanoramaxClient:
         """
         logger.debug(f"Fetching metadata for bounding box: {bbox}")
 
-        if limit <= 0 or limit > self.MAX_LIMIT:
+        capped = limit <= 0 or limit > self.MAX_LIMIT
+        if capped:
             # The endpoint rejects a larger limit outright.
             limit = self.MAX_LIMIT
 
@@ -365,11 +366,12 @@ class PanoramaxClient:
         )
         items = data.get("features") or []
 
-        if len(items) == limit:
+        # Hitting a limit the user chose is expected; only warn when the API cap
+        # cut the results short of what was asked for.
+        if capped and len(items) == limit:
             logger.warning(
-                f"Reached the limit of {limit} images for bounding box {bbox};"
-                " some pictures were left behind. Raise the limit (up to"
-                f" {self.MAX_LIMIT}) or use smaller tiles to get them."
+                f"Reached the API cap of {limit} images for bounding box {bbox};"
+                " some pictures were left behind. Use smaller tiles to get them."
             )
 
         return items  # type: ignore[no-any-return]

--- a/src/streetscapes/sources/panoramax.py
+++ b/src/streetscapes/sources/panoramax.py
@@ -1,0 +1,427 @@
+"""Panoramax related functionality."""
+
+import logging
+from time import sleep
+from typing import TYPE_CHECKING, Any
+
+import geopandas as gpd
+import pandas as pd
+import requests
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
+
+from streetscapes.project import Project
+from streetscapes.sources.common import download_image
+from streetscapes.utils.db_types import (
+    JsonString,
+    UBigInt,
+    UrlString,
+    UtcTimestamp,
+    WktPoint,
+)
+
+if TYPE_CHECKING:
+    import uuid
+    from pathlib import Path
+
+    from streetscapes.utils.geo import Bbox
+    from streetscapes.utils.metadata import ImageMeta
+
+logger = logging.getLogger(__name__)
+
+# The federated catalogue, which indexes the pictures of every Panoramax
+# instance that takes part in it. Pictures stay on the instance that hosts them,
+# so their assets are downloaded from there rather than from the catalogue.
+# https://docs.panoramax.fr/federated-catalog/
+FEDERATED_CATALOGUE = "https://api.panoramax.xyz"
+
+# A picture that covers the full circle is a panorama.
+PANORAMIC_FIELD_OF_VIEW = 360
+
+# Mapping of Panoramax STAC property names to more streetscapes-standard names
+API_FIELDS = {
+    "captured_at": "datetime",
+    "compass_angle": "view:azimuth",
+    "gps_accuracy": "quality:horizontal_accuracy",
+    "license": "license",
+    "sequence_index": "geovisio:rank_in_collection",
+    "uploaded_at": "created",
+}
+
+# Mapping of columns to the STAC asset holding that image
+API_ASSETS = {
+    "image_url": "hd",
+    "thumb_large_url": "sd",
+    "thumb_url": "thumb",
+}
+
+
+class PanoramaxError(RuntimeError):
+    """Raised when the Panoramax API cannot be reached."""
+
+
+def _asset_urls(assets: dict | None) -> dict[str, str]:
+    """Get the URL of each image size the item offers."""
+    assets = assets or {}
+    urls = {}
+    for field, asset in API_ASSETS.items():
+        href = (assets.get(asset) or {}).get("href")
+        if href is not None:
+            urls[field] = href
+    return urls
+
+
+def _optics(properties: dict) -> dict[str, Any]:
+    """Derive the picture's dimensions and its panorama flag from its optics.
+
+    Panoramax reports the dimensions as a pair, and covering the full circle is
+    what makes a picture a panorama.
+    """
+    orientation = properties.get("pers:interior_orientation") or {}
+    optics: dict[str, Any] = {}
+
+    dimensions = orientation.get("sensor_array_dimensions")
+    if isinstance(dimensions, (list, tuple)) and len(dimensions) == 2:
+        optics["width"], optics["height"] = dimensions
+
+    field_of_view = orientation.get("field_of_view")
+    if field_of_view is not None:
+        optics["field_of_view"] = field_of_view
+        optics["is_pano"] = field_of_view == PANORAMIC_FIELD_OF_VIEW
+
+    return optics
+
+
+def _hosting_instance(links: list | None) -> str | None:
+    """Get the instance hosting the picture, which is what its assets point at."""
+    for link in links or []:
+        if link.get("rel") == "via":
+            return link.get("href")  # type: ignore[no-any-return]
+    return None
+
+
+class PanoramaxImage(BaseModel):
+    """Panoramax image record, validated against the database schema.
+
+    Panoramax serves STAC items, which nest most of what is needed under
+    `properties`, `assets` and `links`, so raw API records are flattened (see
+    `_from_api`) before the fields below are validated.
+
+    Field names and types mirror the `panoramax` table schema, except for `image`
+    which is only known after the image itself has been downloaded, and
+    `altitude`, which Panoramax does not report at all.
+    """
+
+    model_config = ConfigDict(extra="ignore", protected_namespaces=())
+
+    # Required entries
+    id: str
+    geometry: WktPoint
+
+    captured_at: UtcTimestamp | None = None
+    compass_angle: float | None = None
+    creator: JsonString | None = None
+    field_of_view: float | None = None
+    gps_accuracy: float | None = None
+    height: UBigInt | None = None
+    image_url: UrlString | None = None
+    instance: UrlString | None = None
+    is_pano: bool | None = None
+    license: str | None = None
+    sequence: str | None = None
+    sequence_index: UBigInt | None = None
+    thumb_large_url: UrlString | None = None
+    thumb_url: UrlString | None = None
+    uploaded_at: UtcTimestamp | None = None
+    width: UBigInt | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _from_api(cls, data: Any) -> Any:
+        """Flatten a STAC item onto the fields of this model.
+
+        Values that are already spelled the way this model expects them are kept,
+        so an already flattened record passes through unchanged.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        record = dict(data)
+        properties = record.get("properties") or {}
+
+        for field, api_field in API_FIELDS.items():
+            if api_field in properties:
+                record.setdefault(field, properties[api_field])
+
+        # Panoramax names the uploader with a bare string, but `creator` is a
+        # JSON column, holding an object for the other sources too.
+        producer = properties.get("geovisio:producer")
+        if producer is not None:
+            record.setdefault("creator", {"username": producer})
+
+        # The sequence a picture belongs to is its STAC collection.
+        if "collection" in record:
+            record.setdefault("sequence", record["collection"])
+
+        for field, value in _asset_urls(record.get("assets")).items():
+            record.setdefault(field, value)
+
+        for field, value in _optics(properties).items():
+            record.setdefault(field, value)
+
+        instance = _hosting_instance(record.get("links"))
+        if instance is not None:
+            record.setdefault("instance", instance)
+
+        return record
+
+    def to_row(self) -> dict[str, Any]:
+        """Get the record as a row for the `panoramax` table."""
+        # `image` is filled in once the image has been downloaded, and Panoramax
+        # reports no altitude.
+        return {"image": None, "altitude": None, **self.model_dump()}
+
+
+def validate_records(records: list[dict]) -> list[PanoramaxImage]:
+    """Validate raw API records, dropping (and reporting) the invalid ones.
+
+    Args:
+        records: Raw STAC items as returned by the Panoramax API.
+
+    Returns:
+        The records that passed validation.
+    """
+    images = []
+    for record in records:
+        try:
+            images.append(PanoramaxImage.model_validate(record))
+        except ValidationError as err:
+            problems = ", ".join(
+                f"{'.'.join(map(str, e['loc']))}: {e['msg']}" for e in err.errors()
+            )
+            logger.warning(
+                f"Skipping malformed Panoramax record (id={record.get('id')!r}):"
+                f" {problems}"
+            )
+
+    skipped = len(records) - len(images)
+    if skipped:
+        logger.info(f"Skipped {skipped}/{len(records)} malformed Panoramax records.")
+
+    return images
+
+
+class PanoramaxClient:
+    """Client for fetching Panoramax image metadata via bounding boxes.
+
+    Queries the federated catalogue by default, which indexes every Panoramax
+    instance taking part in the federation, so one query covers them all. Pass a
+    single instance to restrict the search to it, or to reach an instance that is
+    not federated.
+
+    Records are validated against `PanoramaxImage` and malformed ones are skipped
+    individually. No authentication is required.
+
+    Usage example:
+        from streetscapes.sources.panoramax import PanoramaxClient
+
+        client = PanoramaxClient()
+
+        # bbox: (west, south, east, north)
+        bbox = (4.899, 52.372, 4.901, 52.374)
+
+        # Fetch as pandas DataFrame
+        df = client.fetch_metadata_bbox(bbox)
+
+        # fetch directly as GeoDataFrame
+        gdf = client.fetch_metadata_bbox_gpd(bbox)
+
+        # a single instance rather than the whole federation
+        osm = PanoramaxClient("https://panoramax.openstreetmap.fr")
+    """
+
+    # The search endpoint takes an int16 limit and returns no paging cursor, so
+    # this is the most pictures a bounding box can yield in one go.
+    # https://docs.panoramax.fr/backend/
+    MAX_LIMIT = 32767
+
+    def __init__(
+        self,
+        instance: str = FEDERATED_CATALOGUE,
+        retries: int = 3,
+        timeout: int = 60,
+    ):
+        """Instantiate the client.
+
+        Args:
+            instance : str, optional
+                Base URL of the Panoramax API to query. Defaults to the
+                federated catalogue.
+            retries : int, optional
+                Number of request retries on failure (default is 3).
+            timeout : int, optional
+                Seconds to wait for a response (default is 60).
+        """
+        self.instance = instance.rstrip("/")
+        self.session = requests.Session()
+        self.retries = retries
+        self.timeout = timeout
+
+    @property
+    def search_url(self) -> str:
+        """Get the URL of this instance's search endpoint."""
+        return f"{self.instance}/api/search"
+
+    @property
+    def db_fields(self) -> dict:
+        """Get schema's fields."""
+        return Project.core_tables["panoramax"]["schema"]  # type: ignore[return-value]
+
+    def fetch_image_url(self, image_id: str) -> str | None:
+        """Fetch the image URL from the Panoramax API by image ID."""
+        records = self._request({"ids": image_id, "limit": 1}).get("features") or []
+        if not records:
+            return None
+        return ((records[0].get("assets") or {}).get("hd") or {}).get("href")  # type: ignore[no-any-return]
+
+    def download_image(
+        self,
+        url: str,
+        output_dir: str | Path,
+        image_id: int | str | None,
+        uid: uuid.UUID | None = None,
+        skip_existing: bool = True,
+    ) -> ImageMeta:
+        """Download image from a URL to output_path.
+
+        Args:
+            url: The download URL.
+            output_dir: Destination directory.
+            image_id: Panoramax image ID.
+            uid: Image UUID (from the SHA-256 hash).
+            skip_existing: Don't re-download existing images.
+
+        Returns:
+            Image metadata.
+        """
+        return download_image(
+            self.session,
+            url,
+            output_dir,
+            image_id,
+            source="panoramax",
+            uid=uid,
+            skip_existing=skip_existing,
+        )
+
+    def _request(self, params: dict) -> dict:
+        """Perform a search request, retrying on failure.
+
+        Returns:
+            The parsed response.
+
+        Raises:
+            PanoramaxError: If every attempt failed.
+        """
+        for attempt in range(self.retries):
+            try:
+                res = self.session.get(
+                    self.search_url, params=params, timeout=self.timeout
+                )
+                res.raise_for_status()
+                return res.json()  # type: ignore[no-any-return]
+            except (requests.RequestException, ValueError) as e:
+                logger.error(e)
+                if attempt == self.retries - 1:
+                    break
+                sleep_time = 2**attempt
+                logger.info(
+                    f"Request to {self.search_url} failed - retrying in {sleep_time}s"
+                )
+                sleep(sleep_time)
+
+        raise PanoramaxError(
+            f"The Panoramax API at {self.search_url} did not respond after"
+            f" {self.retries} attempts."
+        )
+
+    def _fetch_bbox(self, bbox: Bbox, limit: int = 1000) -> list[dict]:
+        """Fetch the STAC items for a bounding box.
+
+        Args:
+            bbox: Bounding box as (west, south, east, north).
+            limit: Maximum number of images to fetch.
+
+        Returns:
+            Raw STAC items.
+        """
+        logger.debug(f"Fetching metadata for bounding box: {bbox}")
+
+        if limit <= 0 or limit > self.MAX_LIMIT:
+            # The endpoint rejects a larger limit outright.
+            limit = self.MAX_LIMIT
+
+        data = self._request(
+            {"bbox": ",".join(map(str, bbox)), "limit": limit},
+        )
+        items = data.get("features") or []
+
+        if len(items) == limit:
+            logger.warning(
+                f"Reached the limit of {limit} images for bounding box {bbox};"
+                " some pictures were left behind. Raise the limit (up to"
+                f" {self.MAX_LIMIT}) or use smaller tiles to get them."
+            )
+
+        return items  # type: ignore[no-any-return]
+
+    def fetch_metadata_bbox(self, bbox: Bbox, limit: int = 1000) -> pd.DataFrame:
+        """Fetch metadata for a bounding box and convert to a pandas DataFrame.
+
+        Every record is validated against `PanoramaxImage` before being included;
+        records that fail validation are skipped and reported.
+
+        Note:
+        ----
+        The search endpoint returns no paging cursor and caps the number of
+        results at `MAX_LIMIT`, so a bounding box holding more pictures than that
+        cannot be covered completely in one call.
+
+        Args:
+            bbox : tuple[float, float, float, float]
+                Bounding box as (west, south, east, north).
+            limit : int
+                Maximum number of images to fetch (default 1000).
+
+        Returns:
+            pd.DataFrame
+                DataFrame with Panoramax metadata.
+        """
+        columns = list(self.db_fields)
+        images = validate_records(self._fetch_bbox(bbox, limit))
+
+        if not images:
+            return pd.DataFrame(columns=columns)
+
+        return pd.DataFrame([image.to_row() for image in images], columns=columns)
+
+    def fetch_metadata_bbox_gpd(
+        self, bbox: Bbox, limit: int = 1000
+    ) -> gpd.GeoDataFrame:
+        """Fetch metadata for a bounding box and convert to a GeoDataFrame.
+
+        Geometry columns are parsed from WKT and the CRS is set to EPSG:4326.
+
+        Args:
+            bbox : tuple[float, float, float, float]
+                Bounding box as (west, south, east, north).
+            limit : int
+                Maximum number of images to fetch (default 1000).
+
+        Returns:
+            gpd.GeoDataFrame
+                GeoDataFrame with Panoramax metadata and geometry columns.
+        """
+        df = self.fetch_metadata_bbox(bbox, limit)
+
+        gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkt(df["geometry"]))
+        return gdf.set_crs("EPSG:4326")

--- a/src/streetscapes/utils/geo.py
+++ b/src/streetscapes/utils/geo.py
@@ -14,7 +14,14 @@ Bbox = tuple[float, float, float, float]
 def split_bbox(
     bbox: Bbox, tile_size: float = 0.001
 ) -> tuple[int, Iterable[tuple[Bbox, str]]]:
-    """Split bounding box into set of smaller tiles with fixed tile size."""
+    """Split bounding box into set of smaller tiles with fixed tile size.
+
+    Tiles are aligned to a fixed grid, so that the same patch of the world always
+    gets the same tile ID, and are then clipped to the bounding box. Without the
+    clipping a tile would reach up to `tile_size` beyond the box on every side,
+    which for a box smaller than a tile means asking the source for a far larger
+    area than was requested, and spending any per-tile limit out there.
+    """
     import numpy as np
 
     west, south, east, north = bbox
@@ -35,19 +42,23 @@ def split_bbox(
 
     def iter_tiles():
         for wi, si in product(lon_indices, lat_indices):
-            w = wi * tile_size
-            s = si * tile_size
-            e = (wi + 1) * tile_size
-            n = (si + 1) * tile_size
-
-            tile = [
-                round(w, precision),
-                round(s, precision),
-                round(e, precision),
-                round(n, precision),
+            cell = [
+                round(wi * tile_size, precision),
+                round(si * tile_size, precision),
+                round((wi + 1) * tile_size, precision),
+                round((si + 1) * tile_size, precision),
             ]
 
-            tile_id = "_".join(f"{v:.{precision}f}" for v in tile)
+            # The ID names the grid cell, so it stays the same however the cell
+            # is clipped, while the tile covers only the requested area.
+            tile_id = "_".join(f"{v:.{precision}f}" for v in cell)
+            tile = [
+                max(cell[0], west),
+                max(cell[1], south),
+                min(cell[2], east),
+                min(cell[3], north),
+            ]
+
             yield tile, tile_id
 
     return total, iter_tiles()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from streetscapes import config
 from streetscapes.sources.kartaview import KartaViewClient
 from streetscapes.sources.mapillary import MapillaryClient
+from streetscapes.sources.panoramax import PanoramaxClient
 
 
 @pytest.fixture(autouse=True)
@@ -101,3 +102,53 @@ def fake_kartaview_client(monkeypatch):
     monkeypatch.setattr(KartaViewClient, "download_image", fake_download_image)
 
     return KartaViewClient()
+
+
+@pytest.fixture
+def panoramax_item():
+    """A STAC item as returned by the Panoramax search endpoint."""
+    return {
+        "id": "2ad2b303-59f5-4f8b-a7c1-ccfaef465fbe",
+        "collection": "9802529e-5ec8-433a-95ac-e9d37bf3be7e",
+        "geometry": {"type": "Point", "coordinates": [2.3425668, 48.8582587]},
+        "properties": {
+            "datetime": "2024-10-05T14:24:57+00:00",
+            "created": "2024-10-05T18:24:28.811997+00:00",
+            "view:azimuth": 280,
+            "license": "etalab-2.0",
+            "geovisio:producer": "tdelmas",
+            "geovisio:rank_in_collection": 344,
+            "quality:horizontal_accuracy": 4.0,
+            "pers:interior_orientation": {
+                "field_of_view": 360,
+                "sensor_array_dimensions": [5760, 2880],
+            },
+        },
+        "assets": {
+            "hd": {"href": "https://example.com/pictures/hd.jpg"},
+            "sd": {"href": "https://example.com/pictures/sd.jpg"},
+            "thumb": {"href": "https://example.com/pictures/thumb.jpg"},
+        },
+        "links": [
+            {"rel": "self", "href": "https://api.panoramax.xyz/api/items/x"},
+            {"rel": "via", "href": "https://panoramax.ign.fr"},
+        ],
+    }
+
+
+@pytest.fixture
+def fake_panoramax_client(monkeypatch, panoramax_item):
+    """Patch only the API call of PanoramaxClient, keep the rest intact."""
+
+    def fake_request(self, params):
+        return {"features": [panoramax_item]}
+
+    def fake_download_image(self, url, output_dir, image_id, uid=None, **kwargs):
+        path = Path(output_dir) / f"{image_id}.jpg"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("FAKE IMAGE DATA")  # simulate an image file
+
+    monkeypatch.setattr(PanoramaxClient, "_request", fake_request)
+    monkeypatch.setattr(PanoramaxClient, "download_image", fake_download_image)
+
+    return PanoramaxClient()

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1,3 +1,5 @@
+import pytest
+
 from streetscapes.utils.geo import split_bbox
 
 
@@ -10,3 +12,34 @@ def test_split_bbox_basic():
     assert total == 100 # 10x10 grid
     assert all(len(t[0]) == 4 for t in tiles)
     assert all(isinstance(t[1], str) for t in tiles)
+
+
+def test_split_bbox_clips_to_the_bbox():
+    """A box smaller than a tile must not be widened to the whole grid cell.
+
+    An unclipped tile would ask the source for a far larger area than was
+    requested, and spend any per-tile limit on images outside the box.
+    """
+    bbox = (2.336698, 48.865696, 2.346236, 48.870650)
+    total, tiles = split_bbox(bbox, tile_size=0.05)
+
+    tiles = list(tiles)
+    assert total == 1
+    assert tiles[0][0] == [*bbox]
+    # The ID still names the grid cell, so it is stable across runs.
+    assert tiles[0][1] == "2.300_48.850_2.350_48.900"
+
+
+def test_split_bbox_covers_the_bbox_exactly():
+    """Tiles must together cover the bounding box, without spilling outside it."""
+    west, south, east, north = bbox = (2.20, 48.80, 2.45, 48.92)
+    total, tiles = split_bbox(bbox, tile_size=0.05)
+
+    tiles = [t for t, _ in tiles]
+    assert total == len(tiles)
+
+    covered = sum((t[2] - t[0]) * (t[3] - t[1]) for t in tiles)
+    assert covered == pytest.approx((east - west) * (north - south))
+    assert all(
+        t[0] >= west and t[1] >= south and t[2] <= east and t[3] <= north for t in tiles
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ class TestCLIHelp:
         result = run_cli("streetscapes fetch-metadata --help")
         assert "mapillary" in result
         assert "kartaview" in result
+        assert "panoramax" in result
 
     def test_fetch_metadata_mapillary_help(self):
         result = run_cli("streetscapes fetch-metadata mapillary --help")
@@ -58,10 +59,18 @@ class TestCLIHelp:
         # The limit is for the whole bounding box, not per tile.
         assert "--tile-limit" not in result
 
+    def test_fetch_metadata_panoramax_help(self):
+        result = run_cli("streetscapes fetch-metadata panoramax --help")
+        assert "BBOX" in result
+        assert "--tile-size" in result
+        assert "--tile-limit" in result
+        assert "--instance" in result
+
     def test_download_images_help(self):
         result = run_cli("streetscapes download-images --help")
         assert "mapillary" in result
         assert "kartaview" in result
+        assert "panoramax" in result
 
     def test_download_images_mapillary_help(self):
         result = run_cli("streetscapes download-images mapillary --help")
@@ -73,6 +82,14 @@ class TestCLIHelp:
         assert "--skip-existing" in result
         # KartaView needs no authentication.
         assert "--token" not in result
+
+    def test_download_images_panoramax_help(self):
+        result = run_cli("streetscapes download-images panoramax --help")
+        assert "--skip-existing" in result
+        # Panoramax needs no authentication, and the instance to download from
+        # is whichever one the metadata came from.
+        assert "--token" not in result
+        assert "--instance" not in result
 
     def test_export_help(self):
         result = run_cli("streetscapes export --help")

--- a/tests/test_panoramax_client.py
+++ b/tests/test_panoramax_client.py
@@ -1,0 +1,206 @@
+import pytest
+from pydantic import ValidationError
+
+from streetscapes.project import Project
+from streetscapes.sources.panoramax import (
+    FEDERATED_CATALOGUE,
+    PanoramaxClient,
+    PanoramaxImage,
+    validate_records,
+)
+
+
+def test_defaults_to_the_federated_catalogue():
+    """One query should cover every federated instance unless told otherwise."""
+    assert PanoramaxClient().instance == FEDERATED_CATALOGUE
+    assert PanoramaxClient().search_url == f"{FEDERATED_CATALOGUE}/api/search"
+
+
+def test_instance_override():
+    """A single instance can be queried instead, however it is spelled."""
+    client = PanoramaxClient("https://panoramax.openstreetmap.fr/")
+
+    assert client.search_url == "https://panoramax.openstreetmap.fr/api/search"
+
+
+def test_fetch_metadata_bbox(fake_panoramax_client):
+    df = fake_panoramax_client.fetch_metadata_bbox((2.34, 48.85, 2.35, 48.86))
+
+    assert not df.empty
+    assert "geometry" in df.columns
+    assert df.iloc[0]["id"] == "2ad2b303-59f5-4f8b-a7c1-ccfaef465fbe"
+
+
+def test_fetch_metadata_bbox_matches_db_schema(fake_panoramax_client):
+    """The DataFrame columns should mirror the `panoramax` table exactly."""
+    df = fake_panoramax_client.fetch_metadata_bbox((2.34, 48.85, 2.35, 48.86))
+
+    assert list(df.columns) == list(Project.core_tables["panoramax"]["schema"])
+
+
+def test_fetch_metadata_bbox_empty(fake_panoramax_client, monkeypatch):
+    """An empty tile still yields a DataFrame with the schema's columns."""
+    monkeypatch.setattr(
+        type(fake_panoramax_client), "_request", lambda self, params: {"features": []}
+    )
+    df = fake_panoramax_client.fetch_metadata_bbox((2.34, 48.85, 2.35, 48.86))
+
+    assert df.empty
+    assert list(df.columns) == list(Project.core_tables["panoramax"]["schema"])
+
+
+@pytest.fixture
+def spy_request(fake_panoramax_client, monkeypatch):
+    """Capture the parameters the client sends to the search endpoint."""
+    seen: dict = {}
+
+    def spy(self, params):
+        seen.update(params)
+        return {"features": []}
+
+    monkeypatch.setattr(type(fake_panoramax_client), "_request", spy)
+    return seen
+
+
+@pytest.mark.parametrize("limit", [99999, 0])
+def test_fetch_caps_limit_at_the_api_maximum(fake_panoramax_client, spy_request, limit):
+    """The endpoint rejects a limit above its own maximum outright."""
+    fake_panoramax_client.fetch_metadata_bbox((2.34, 48.85, 2.35, 48.86), limit=limit)
+
+    assert spy_request["limit"] == PanoramaxClient.MAX_LIMIT
+
+
+def test_fetch_queries_the_bbox_as_given(fake_panoramax_client, spy_request):
+    """The bounding box must not be widened; the limit applies to what it covers.
+
+    Snapping it to a coarse grid would spend the limit on pictures outside the
+    area that was asked for, and return none of the ones inside it.
+    """
+    fake_panoramax_client.fetch_metadata_bbox(
+        (2.336698, 48.865696, 2.346236, 48.870650)
+    )
+
+    assert spy_request["bbox"] == "2.336698,48.865696,2.346236,48.87065"
+
+
+def test_model_matches_db_schema():
+    """The model and the `panoramax` table must not drift apart."""
+    schema = Project.core_tables["panoramax"]["schema"]
+
+    # `image` is not part of the API response and Panoramax reports no altitude,
+    # so neither is a model field.
+    assert set(PanoramaxImage.model_fields) | {"image", "altitude"} == set(schema)
+
+
+def test_model_conversions(panoramax_item):
+    image = PanoramaxImage.model_validate(panoramax_item)
+
+    assert image.id == "2ad2b303-59f5-4f8b-a7c1-ccfaef465fbe"
+    assert image.geometry == "POINT (2.3425668 48.8582587)"
+    assert image.captured_at.isoformat() == "2024-10-05T14:24:57+00:00"
+    assert image.uploaded_at.isoformat() == "2024-10-05T18:24:28.811997+00:00"
+    assert image.compass_angle == 280
+    assert image.gps_accuracy == 4.0
+    assert image.license == "etalab-2.0"
+    # The sequence a picture belongs to is its STAC collection.
+    assert image.sequence == "9802529e-5ec8-433a-95ac-e9d37bf3be7e"
+    assert image.sequence_index == 344
+
+
+def test_model_wraps_the_bare_producer(panoramax_item):
+    """`creator` is a JSON column, so a bare producer name has to be wrapped."""
+    image = PanoramaxImage.model_validate(panoramax_item)
+
+    assert image.creator == '{"username":"tdelmas"}'
+
+
+def test_model_flattens_assets(panoramax_item):
+    image = PanoramaxImage.model_validate(panoramax_item)
+
+    assert image.image_url == "https://example.com/pictures/hd.jpg"
+    assert image.thumb_large_url == "https://example.com/pictures/sd.jpg"
+    assert image.thumb_url == "https://example.com/pictures/thumb.jpg"
+
+
+def test_model_records_the_hosting_instance(panoramax_item):
+    """Assets live on the instance that hosts them, not on the catalogue."""
+    image = PanoramaxImage.model_validate(panoramax_item)
+
+    assert image.instance == "https://panoramax.ign.fr"
+
+
+def test_model_derives_dimensions_and_pano(panoramax_item):
+    """Panoramax reports the dimensions as a pair and no panorama flag."""
+    pano = PanoramaxImage.model_validate(panoramax_item)
+
+    assert (pano.width, pano.height) == (5760, 2880)
+    assert (pano.field_of_view, pano.is_pano) == (360, True)
+
+
+@pytest.mark.parametrize("field_of_view", [14, 40, 92, 95])
+def test_model_narrow_field_of_view_is_not_panoramic(panoramax_item, field_of_view):
+    """Only a picture covering the full circle is a panorama."""
+    item = {**panoramax_item, "properties": {**panoramax_item["properties"]}}
+    item["properties"]["pers:interior_orientation"] = {
+        "field_of_view": field_of_view,
+        "sensor_array_dimensions": [4000, 3000],
+    }
+    image = PanoramaxImage.model_validate(item)
+
+    assert image.is_pano is False
+    assert image.field_of_view == field_of_view
+
+
+def test_model_defaults_missing_fields():
+    """Fields the API leaves out become NULLs rather than missing columns."""
+    image = PanoramaxImage.model_validate(
+        {"id": "abc", "geometry": {"coordinates": [2.34, 48.85]}}
+    )
+
+    assert image.image_url is None
+    assert image.is_pano is None
+    assert image.instance is None
+    assert set(image.to_row()) == set(Project.core_tables["panoramax"]["schema"])
+    # Panoramax reports no altitude, but the column is part of the schema.
+    assert image.to_row()["altitude"] is None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("geometry", {"type": "Point", "coordinates": [2.34, 948.85]}),
+        ("geometry", {"type": "Point", "coordinates": [2.34]}),
+        ("geometry", {"type": "Point", "coordinates": ["east", "north"]}),
+        ("geometry", None),
+    ],
+)
+def test_model_rejects_bad_geometry(panoramax_item, field, value):
+    with pytest.raises(ValidationError):
+        PanoramaxImage.model_validate({**panoramax_item, field: value})
+
+
+def test_model_rejects_bad_asset_url(panoramax_item):
+    item = {**panoramax_item, "assets": {"hd": {"href": "not-a-url"}}}
+
+    with pytest.raises(ValidationError):
+        PanoramaxImage.model_validate(item)
+
+
+def test_model_requires_id_and_geometry(panoramax_item):
+    for field in ("id", "geometry"):
+        record = {k: v for k, v in panoramax_item.items() if k != field}
+        with pytest.raises(ValidationError):
+            PanoramaxImage.model_validate(record)
+
+
+def test_validate_records_skips_bad_images(panoramax_item):
+    """A malformed item is dropped without discarding the rest of the tile."""
+    records = [
+        panoramax_item,
+        {**panoramax_item, "id": "bad", "geometry": {"coordinates": [2.34, 948.85]}},
+        {**panoramax_item, "id": "good"},
+    ]
+
+    images = validate_records(records)
+
+    assert [image.id for image in images] == [panoramax_item["id"], "good"]


### PR DESCRIPTION
Closes #200 

Panoramax is a federated street level images database. It largely contains images of France but also has instances focused on other areas.

For usage see docs/cli.

<hr>

During testing a bug in the tiling logic came up; if you have a bbox which is smaller than a tile, the images returned by the metadata fetcher would still be filtered for your original bbox again, making the per tile image limit not work properly.

This is fixed by trimming the tiles to the bbox extents