### PR TITLE
Add pano-only option to fetch commands

### DIFF
--- a/docs/tutorial/cli.md
+++ b/docs/tutorial/cli.md
@@ -79,6 +79,7 @@ Fetch metadata from the Mapillary API.
 ╭─ Parameters ───────────────────────────────────────────────────────────────────╮
 │ --tile-size   Tile size in degrees. [default: 0.001]                           │
 │ --tile-limit  Maximum number of images per tile. [default: 1000]               │
+│ --pano-only   Only fetch panoramic images. [default: False]                    │
 │ --token       Mapillary OAuth token (if not set via MAPILLARY_TOKEN).          │
 │ --project     An optional project to attach to.                                │
 ╰────────────────────────────────────────────────────────────────────────────────╯
@@ -128,6 +129,9 @@ Fetch metadata from the KartaView API.
 ╭─ Parameters ───────────────────────────────────────────────────────────────────╮
 │ --image-limit  Maximum number of images to fetch (0 for no limit). [default:   │
 │                1000]                                                           │
+│ --pano-only    Only fetch panoramic images. The API cannot filter on this,     │
+│                so the whole listing may be paged through to find them.         │
+│                [default: False]                                                │
 │ --project      An optional project to attach to.                               │
 ╰────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -186,6 +190,9 @@ much larger than Mapillary's, as its limit is far higher.
 │ --tile-size   Tile size in degrees. [default: 0.05]                            │
 │ --tile-limit  Maximum number of images per tile (at most 32767, which is also  │
 │               what 0 means: the most the API will return). [default: 1000]     │
+│ --pano-only   Only fetch panoramic images. A single --instance cannot          │
+│               filter on this itself, so there the tile limit applies           │
+│               before the other images are dropped. [default: False]            │
 │ --instance    A single Panoramax instance to query, such as                    │
 │               'https://panoramax.openstreetmap.fr'. Defaults to the federated  │
 │               catalogue.                                                       │

--- a/src/streetscapes/cli/fetch_metadata.py
+++ b/src/streetscapes/cli/fetch_metadata.py
@@ -5,9 +5,9 @@ Usage:
 """
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
-from cyclopts import App
+from cyclopts import App, Parameter
 from rich.progress import track
 
 from streetscapes import CFG
@@ -29,6 +29,7 @@ def mapillary(
     *,
     tile_size: float = 0.001,
     tile_limit: int = 1000,
+    pano_only: Annotated[bool, Parameter(negative="")] = False,
     token: str | None = None,
     project: str | None = None,
 ):
@@ -38,6 +39,7 @@ def mapillary(
         bbox: Bounding box (WEST SOUTH EAST NORTH).
         tile_size: Tile size in degrees.
         tile_limit: Maximum number of images per tile.
+        pano_only: Only fetch panoramic images.
         token: Mapillary OAuth token (if not set via MAPILLARY_TOKEN).
         project: An optional project to attach to.
     """
@@ -62,7 +64,7 @@ def mapillary(
     for tile, _tile_id in track(
         tiles, description="Fetching tiles", total=ntiles, console=console
     ):
-        df = m.fetch_metadata_bbox(tile, tile_limit)
+        df = m.fetch_metadata_bbox(tile, tile_limit, pano_only)
 
         # TODO: maybe this failsafe/optimization is not necessary?
         if len(df) == 0:
@@ -79,6 +81,7 @@ def kartaview(
     /,
     *,
     image_limit: int = 1000,
+    pano_only: Annotated[bool, Parameter(negative="")] = False,
     project: str | None = None,
 ):
     """Fetch metadata from the KartaView API.
@@ -86,6 +89,8 @@ def kartaview(
     Args:
         bbox: Bounding box (WEST SOUTH EAST NORTH).
         image_limit: Maximum number of images to fetch (0 for no limit).
+        pano_only: Only fetch panoramic images. The API cannot filter on this,
+            so the whole listing may be paged through to find them.
         project: An optional project to attach to.
     """
     from streetscapes.project import Project
@@ -98,7 +103,7 @@ def kartaview(
 
     try:
         with console.status("Fetching images..."):
-            df = client.fetch_metadata_bbox(bbox, image_limit)
+            df = client.fetch_metadata_bbox(bbox, image_limit, pano_only)
     except KartaViewError as err:
         logger.error(str(err))
         raise SystemExit(1) from err
@@ -116,6 +121,7 @@ def panoramax(
     *,
     tile_size: float = 0.05,
     tile_limit: int = 1000,
+    pano_only: Annotated[bool, Parameter(negative="")] = False,
     instance: str | None = None,
     project: str | None = None,
 ):
@@ -134,6 +140,9 @@ def panoramax(
         tile_size: Tile size in degrees.
         tile_limit: Maximum number of images per tile (at most 32767, which is
             also what 0 means: the most the API will return).
+        pano_only: Only fetch panoramic images. Not ever instance can filter
+            on this itself, so there the tile limit applies before the
+            non-pano images are dropped.
         instance: A single Panoramax instance to query, such as
             'https://panoramax.openstreetmap.fr'. Defaults to the federated
             catalogue.
@@ -157,7 +166,7 @@ def panoramax(
         for tile, _tile_id in track(
             tiles, description="Fetching tiles", total=ntiles, console=console
         ):
-            df = client.fetch_metadata_bbox(tile, tile_limit)
+            df = client.fetch_metadata_bbox(tile, tile_limit, pano_only)
 
             if len(df) == 0:
                 continue

--- a/src/streetscapes/sources/README.md
+++ b/src/streetscapes/sources/README.md
@@ -30,6 +30,8 @@ streetscapes fetch-metadata mapillary \
 * `bbox`: Bounding box `[west, south, east, north]` to fetch images from.
 * `tile-size`: Optional tiling of the bounding box (default 0.01°).
 * `output-file`: Path to save the GeoParquet manifest.
+* `pano-only`: Only fetch panoramic images. The API filters on `is_pano` itself, so
+  `tile-limit` counts panoramas only.
 * `token`: OAuth token for Mapillary API.
 
 ### KartaView
@@ -44,6 +46,10 @@ streetscapes fetch-metadata kartaview \
 * `image-limit`: Maximum number of images to fetch for the bounding box (`0` for
   no limit). The KartaView API pages through a bounding box of any size, so there
   is no tiling, and the limit is not per tile as it is for Mapillary.
+* `pano-only`: Only fetch panoramic images, i.e. those whose `projection` is not
+  `PLANE`. The API cannot filter on this, so the listing is filtered as it comes
+  in and paged through until `image-limit` panoramas are found — in an area with
+  few of them, that can mean listing the whole bounding box.
 
 No token is required. Metadata is collected in two steps, as no single public
 endpoint both covers a bounding box and returns complete records: the photos in
@@ -66,6 +72,10 @@ streetscapes fetch-metadata panoramax \
   what `0` means, the most the API will return.
 * `instance`: A single Panoramax instance to query. Optional — defaults to the
   federated catalogue.
+* `pano-only`: Only fetch panoramic images, i.e. those with a 360° field of view.
+  The federated catalogue filters on this itself, but single instances reject the
+  filter, so with `--instance` the results are filtered afterwards and
+  `tile-limit` applies before the other images are dropped.
 
 No token is required. Panoramax is a federation of instances rather than one
 server, so by default the [federated catalogue](https://docs.panoramax.fr/federated-catalog/)

--- a/src/streetscapes/sources/kartaview.py
+++ b/src/streetscapes/sources/kartaview.py
@@ -66,6 +66,13 @@ def _point(lon: Any, lat: Any) -> dict | None:
     return {"coordinates": [lon, lat]}
 
 
+def _is_pano(projection: Any) -> bool | None:
+    """Tell whether a projection is panoramic; KartaView has no flag for it."""
+    if projection is None:
+        return None
+    return str(projection).upper() != "PLANE"
+
+
 def _timestamp(value: Any) -> Any:
     """Discard the placeholders KartaView uses for a missing timestamp."""
     if isinstance(value, str) and (not value.strip() or value.startswith("0000")):
@@ -140,9 +147,9 @@ class KartaViewImage(BaseModel):
                 "computed_geometry", _point(record["matchLng"], record["matchLat"])
             )
 
-        projection = record.get("projection")
-        if projection is not None:
-            record.setdefault("is_pano", str(projection).upper() != "PLANE")
+        is_pano = _is_pano(record.get("projection"))
+        if is_pano is not None:
+            record.setdefault("is_pano", is_pano)
 
         username = record.get("username")
         if username is not None:
@@ -303,12 +310,17 @@ class KartaViewClient:
             " worth retrying."
         )
 
-    def _list_bbox(self, bbox: Bbox, limit: int = 1000) -> list[dict]:
+    def _list_bbox(
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
+    ) -> list[dict]:
         """List the photos in a bounding box, paging through the results.
 
         Args:
             bbox: Bounding box as (west, south, east, north).
             limit: Maximum number of photos to list (0 for no limit).
+            pano_only: Only list panoramic photos. The API cannot filter on this,
+                so the listing is filtered as it comes in, and paging continues
+                until `limit` panoramas have been found.
 
         Returns:
             The (partial) photo records returned by the listing endpoint.
@@ -316,7 +328,12 @@ class KartaViewClient:
         logger.debug(f"Listing photos for bounding box: {bbox}")
 
         west, south, east, north = bbox
-        page_size = self.PAGE_SIZE if limit <= 0 else min(limit, self.PAGE_SIZE)
+        # When filtering there is no telling how much of a page is kept, so a
+        # small page would only mean many more requests for the same photos.
+        if limit <= 0 or pano_only:
+            page_size = self.PAGE_SIZE
+        else:
+            page_size = min(limit, self.PAGE_SIZE)
 
         photos: list[dict] = []
         page = 1
@@ -336,8 +353,12 @@ class KartaViewClient:
             )
 
             items = data.get("currentPageItems") or []
-            photos.extend(items)
+            if pano_only:
+                photos.extend(p for p in items if _is_pano(p.get("projection")))
+            else:
+                photos.extend(items)
 
+            # A short page is the last one, whatever was kept of it.
             if len(items) < page_size or (0 < limit <= len(photos)):
                 break
 
@@ -364,17 +385,23 @@ class KartaViewClient:
 
         return records
 
-    def _fetch_bbox(self, bbox: Bbox, limit: int = 1000) -> list[dict]:
+    def _fetch_bbox(
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
+    ) -> list[dict]:
         """Fetch the full photo records for a bounding box.
 
         Args:
             bbox: Bounding box as (west, south, east, north).
             limit: Maximum number of images to fetch (0 for no limit).
+            pano_only: Only fetch panoramic images.
 
         Returns:
             Raw photo records, enriched with the listing's `username`.
         """
-        listed = {photo["id"]: photo for photo in self._list_bbox(bbox, limit)}
+        listed = {
+            photo["id"]: photo
+            for photo in self._list_bbox(bbox, limit, pano_only=pano_only)
+        }
 
         if not listed:
             return []
@@ -389,7 +416,9 @@ class KartaViewClient:
 
         return records
 
-    def fetch_metadata_bbox(self, bbox: Bbox, limit: int = 1000) -> pd.DataFrame:
+    def fetch_metadata_bbox(
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
+    ) -> pd.DataFrame:
         """Fetch metadata for a bounding box and convert to a pandas DataFrame.
 
         Every record is validated against `KartaViewImage` before being included;
@@ -400,13 +429,15 @@ class KartaViewClient:
                 Bounding box as (west, south, east, north).
             limit : int
                 Maximum number of images to fetch (default 1000, 0 for no limit).
+            pano_only : bool
+                Only fetch panoramic images (default False).
 
         Returns:
             pd.DataFrame
                 DataFrame with KartaView metadata.
         """
         columns = list(self.db_fields)
-        images = validate_records(self._fetch_bbox(bbox, limit))
+        images = validate_records(self._fetch_bbox(bbox, limit, pano_only=pano_only))
 
         if not images:
             return pd.DataFrame(columns=columns)
@@ -414,7 +445,7 @@ class KartaViewClient:
         return pd.DataFrame([image.to_row() for image in images], columns=columns)
 
     def fetch_metadata_bbox_gpd(
-        self, bbox: Bbox, limit: int = 1000
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
     ) -> gpd.GeoDataFrame:
         """Fetch metadata for a bounding box and convert to a GeoDataFrame.
 
@@ -425,12 +456,14 @@ class KartaViewClient:
                 Bounding box as (west, south, east, north).
             limit : int
                 Maximum number of images to fetch (default 1000, 0 for no limit).
+            pano_only : bool
+                Only fetch panoramic images (default False).
 
         Returns:
             gpd.GeoDataFrame
                 GeoDataFrame with KartaView metadata and geometry columns.
         """
-        df = self.fetch_metadata_bbox(bbox, limit)
+        df = self.fetch_metadata_bbox(bbox, limit, pano_only)
 
         gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkt(df["geometry"]))
         return gdf.set_crs("EPSG:4326")

--- a/src/streetscapes/sources/mapillary.py
+++ b/src/streetscapes/sources/mapillary.py
@@ -206,7 +206,9 @@ class MapillaryClient:
             skip_existing=skip_existing,
         )
 
-    def _fetch_bbox(self, bbox: Bbox, limit: int = 1000) -> list[dict]:
+    def _fetch_bbox(
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
+    ) -> list[dict]:
         """Perform the raw API request to Mapillary for a single bounding box tile."""
         logger.debug(f"Fetching metadata for bounding box: {bbox}")
 
@@ -215,6 +217,9 @@ class MapillaryClient:
             "fields": ",".join(MapillaryImage.api_fields()),
             "limit": limit,
         }
+        if pano_only:
+            # Filtered by the Mapillary API
+            params["is_pano"] = "true"
 
         for attempt in range(self.retries):
             try:
@@ -230,7 +235,9 @@ class MapillaryClient:
         logger.warning(f"Failed to retrieve metadata for bounding box: {bbox}")
         return []
 
-    def fetch_metadata_bbox(self, bbox: Bbox, limit: int = 1000) -> pd.DataFrame:
+    def fetch_metadata_bbox(
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
+    ) -> pd.DataFrame:
         """Fetch metadata for a bounding box and convert to a pandas DataFrame.
 
         Every record is validated against `MapillaryImage` before being included;
@@ -247,13 +254,15 @@ class MapillaryClient:
                 Bounding box as (west, south, east, north).
             limit : int
                 Maximum number of images to fetch (default 1000).
+            pano_only : bool
+                Only fetch panoramic images (default False).
 
         Returns:
             pd.DataFrame
                 DataFrame with Mapillary metadata.
         """
         columns = list(self.db_fields)
-        images = validate_records(self._fetch_bbox(bbox, limit))
+        images = validate_records(self._fetch_bbox(bbox, limit, pano_only=pano_only))
 
         if not images:
             return pd.DataFrame(columns=columns)
@@ -261,7 +270,7 @@ class MapillaryClient:
         return pd.DataFrame([image.to_row() for image in images], columns=columns)
 
     def fetch_metadata_bbox_gpd(
-        self, bbox: Bbox, limit: int = 1000
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
     ) -> gpd.GeoDataFrame:
         """Fetch metadata for a bounding box and convert to a GeoDataFrame.
 
@@ -278,12 +287,14 @@ class MapillaryClient:
                 Bounding box as (west, south, east, north).
             limit : int
                 Maximum number of images to fetch (default 1000).
+            pano_only : bool
+                Only fetch panoramic images (default False).
 
         Returns:
             gpd.GeoDataFrame
                 GeoDataFrame with Mapillary metadata and geometry columns.
         """
-        df = self.fetch_metadata_bbox(bbox, limit)
+        df = self.fetch_metadata_bbox(bbox, limit, pano_only)
 
         gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkt(df["geometry"]))
         return gdf.set_crs("EPSG:4326")

--- a/src/streetscapes/sources/panoramax.py
+++ b/src/streetscapes/sources/panoramax.py
@@ -344,12 +344,25 @@ class PanoramaxClient:
             f" {self.retries} attempts."
         )
 
-    def _fetch_bbox(self, bbox: Bbox, limit: int = 1000) -> list[dict]:
+    @property
+    def filters_pano(self) -> bool:
+        """Tell whether the search endpoint can filter on panoramas itself.
+
+        The federated catalogue accepts a filter on the field of view, but single
+        instances reject it as unsupported.
+        """
+        return self.instance == FEDERATED_CATALOGUE
+
+    def _fetch_bbox(
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
+    ) -> list[dict]:
         """Fetch the STAC items for a bounding box.
 
         Args:
             bbox: Bounding box as (west, south, east, north).
             limit: Maximum number of images to fetch.
+            pano_only: Have the API return panoramic images only, if it can (see
+                `filters_pano`). The items are not filtered otherwise.
 
         Returns:
             Raw STAC items.
@@ -361,9 +374,11 @@ class PanoramaxClient:
             # The endpoint rejects a larger limit outright.
             limit = self.MAX_LIMIT
 
-        data = self._request(
-            {"bbox": ",".join(map(str, bbox)), "limit": limit},
-        )
+        params: dict[str, Any] = {"bbox": ",".join(map(str, bbox)), "limit": limit}
+        if pano_only and self.filters_pano:
+            params["filter"] = f"field_of_view={PANORAMIC_FIELD_OF_VIEW}"
+
+        data = self._request(params)
         items = data.get("features") or []
 
         # Hitting a limit the user chose is expected; only warn when the API cap
@@ -376,7 +391,9 @@ class PanoramaxClient:
 
         return items  # type: ignore[no-any-return]
 
-    def fetch_metadata_bbox(self, bbox: Bbox, limit: int = 1000) -> pd.DataFrame:
+    def fetch_metadata_bbox(
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
+    ) -> pd.DataFrame:
         """Fetch metadata for a bounding box and convert to a pandas DataFrame.
 
         Every record is validated against `PanoramaxImage` before being included;
@@ -393,13 +410,21 @@ class PanoramaxClient:
                 Bounding box as (west, south, east, north).
             limit : int
                 Maximum number of images to fetch (default 1000).
+            pano_only : bool
+                Only fetch panoramic images (default False). A single instance
+                cannot filter on this itself, so there the limit applies before
+                the other images are dropped, and fewer may be returned.
 
         Returns:
             pd.DataFrame
                 DataFrame with Panoramax metadata.
         """
         columns = list(self.db_fields)
-        images = validate_records(self._fetch_bbox(bbox, limit))
+        images = validate_records(self._fetch_bbox(bbox, limit, pano_only=pano_only))
+
+        if pano_only:
+            # Needed where the API could not filter
+            images = [image for image in images if image.is_pano]
 
         if not images:
             return pd.DataFrame(columns=columns)
@@ -407,7 +432,7 @@ class PanoramaxClient:
         return pd.DataFrame([image.to_row() for image in images], columns=columns)
 
     def fetch_metadata_bbox_gpd(
-        self, bbox: Bbox, limit: int = 1000
+        self, bbox: Bbox, limit: int = 1000, pano_only: bool = False
     ) -> gpd.GeoDataFrame:
         """Fetch metadata for a bounding box and convert to a GeoDataFrame.
 
@@ -418,12 +443,14 @@ class PanoramaxClient:
                 Bounding box as (west, south, east, north).
             limit : int
                 Maximum number of images to fetch (default 1000).
+            pano_only : bool
+                Only fetch panoramic images (default False).
 
         Returns:
             gpd.GeoDataFrame
                 GeoDataFrame with Panoramax metadata and geometry columns.
         """
-        df = self.fetch_metadata_bbox(bbox, limit)
+        df = self.fetch_metadata_bbox(bbox, limit, pano_only)
 
         gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkt(df["geometry"]))
         return gdf.set_crs("EPSG:4326")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def fake_mapillary_client(monkeypatch):
     """Patch only the API-call methods of MapillaryClient, keep the rest intact."""
 
     # Fake implementations
-    def fake_fetch_bbox(self, bbox, limit=1000):
+    def fake_fetch_bbox(self, bbox, limit=1000, pano_only=False):
         return [
             {
                 "id": "1",
@@ -67,7 +67,7 @@ def fake_kartaview_client(monkeypatch):
     into the detailed records is still exercised.
     """
 
-    def fake_list_bbox(self, bbox, limit=1000):
+    def fake_list_bbox(self, bbox, limit=1000, pano_only=False):
         # The listing endpoint reports the uploader, the photo endpoint doesn't.
         return [{"id": "1234567890", "username": "someone"}]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,11 +51,13 @@ class TestCLIHelp:
         assert "BBOX" in result
         assert "--tile-size" in result
         assert "--tile-limit" in result
+        assert "--pano-only" in result
 
     def test_fetch_metadata_kartaview_help(self):
         result = run_cli("streetscapes fetch-metadata kartaview --help")
         assert "BBOX" in result
         assert "--image-limit" in result
+        assert "--pano-only" in result
         # The limit is for the whole bounding box, not per tile.
         assert "--tile-limit" not in result
 
@@ -65,6 +67,7 @@ class TestCLIHelp:
         assert "--tile-size" in result
         assert "--tile-limit" in result
         assert "--instance" in result
+        assert "--pano-only" in result
 
     def test_download_images_help(self):
         result = run_cli("streetscapes download-images --help")

--- a/tests/test_kartaview_client.py
+++ b/tests/test_kartaview_client.py
@@ -61,12 +61,64 @@ def test_fetch_metadata_bbox_matches_db_schema(fake_kartaview_client):
 def test_fetch_metadata_bbox_empty(fake_kartaview_client, monkeypatch):
     """An empty bounding box still yields a DataFrame with the schema's columns."""
     monkeypatch.setattr(
-        type(fake_kartaview_client), "_list_bbox", lambda self, bbox, limit=1000: []
+        type(fake_kartaview_client), "_list_bbox", lambda self, bbox, *a, **kw: []
     )
     df = fake_kartaview_client.fetch_metadata_bbox((4.89, 52.37, 4.91, 52.38))
 
     assert df.empty
     assert list(df.columns) == list(Project.core_tables["kartaview"]["schema"])
+
+
+@pytest.fixture
+def paged_listing(monkeypatch):
+    """Serve a listing of full pages alternating flat photos and panoramas."""
+    pages = []
+
+    def fake_request(self, method, url, **kwargs):
+        page = int(kwargs["files"]["page"][1])
+        size = int(kwargs["files"]["ipp"][1])
+        pages.append(page)
+        # Page 3 is the last, and short.
+        count = size if page < 3 else size // 2
+        items = [
+            {
+                "id": str(page * 10_000 + i),
+                "projection": "SPHERE" if i % 2 else "PLANE",
+            }
+            for i in range(count)
+        ]
+        return {"currentPageItems": items}
+
+    monkeypatch.setattr(KartaViewClient, "_request", fake_request)
+    return pages
+
+
+def test_list_pano_only_keeps_panoramas(paged_listing):
+    photos = KartaViewClient()._list_bbox((4.89, 52.37, 4.91, 52.38), 0, True)
+
+    assert photos
+    assert {photo["projection"] for photo in photos} == {"SPHERE"}
+    # A filtered page is not a short page: paging runs to the real last one.
+    assert paged_listing == [1, 2, 3]
+
+
+def test_list_pano_only_limit_counts_panoramas(paged_listing):
+    """Paging continues until the limit is met by panoramas, not by photos."""
+    limit = KartaViewClient.PAGE_SIZE
+    photos = KartaViewClient()._list_bbox((4.89, 52.37, 4.91, 52.38), limit, True)
+
+    assert len(photos) == limit
+    assert {photo["projection"] for photo in photos} == {"SPHERE"}
+    assert paged_listing == [1, 2]
+
+
+def test_list_pano_only_requests_full_pages(paged_listing):
+    """A small limit must not shrink the pages that are being filtered."""
+    photos = KartaViewClient()._list_bbox((4.89, 52.37, 4.91, 52.38), 5, True)
+
+    assert len(photos) == 5
+    # The first full page already holds enough panoramas.
+    assert paged_listing == [1]
 
 
 def test_fetch_metadata_bbox_adds_uploader(fake_kartaview_client):

--- a/tests/test_mapillary_client.py
+++ b/tests/test_mapillary_client.py
@@ -1,8 +1,13 @@
 import pytest
+import requests
 from pydantic import ValidationError
 
 from streetscapes.project import Project
-from streetscapes.sources.mapillary import MapillaryImage, validate_records
+from streetscapes.sources.mapillary import (
+    MapillaryClient,
+    MapillaryImage,
+    validate_records,
+)
 
 
 @pytest.fixture
@@ -40,12 +45,37 @@ def test_fetch_metadata_bbox_matches_db_schema(fake_mapillary_client):
 def test_fetch_metadata_bbox_empty(fake_mapillary_client, monkeypatch):
     """An empty tile still yields a DataFrame with the schema's columns."""
     monkeypatch.setattr(
-        type(fake_mapillary_client), "_fetch_bbox", lambda self, bbox, limit=1000: []
+        type(fake_mapillary_client), "_fetch_bbox", lambda self, bbox, *a, **kw: []
     )
     df = fake_mapillary_client.fetch_metadata_bbox((4.89, 52.37, 4.91, 52.38))
 
     assert df.empty
     assert list(df.columns) == list(Project.core_tables["mapillary"]["schema"])
+
+
+@pytest.mark.parametrize("pano_only", [False, True])
+def test_fetch_filters_panoramas_in_the_api(monkeypatch, pano_only):
+    """The API filters on `is_pano`, so the limit counts panoramas only."""
+    seen: dict = {}
+
+    class _Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": []}
+
+    def spy(self, url, params, **kwargs):
+        seen.update(params)
+        return _Response()
+
+    monkeypatch.setattr(requests.Session, "get", spy)
+
+    MapillaryClient("fake_token").fetch_metadata_bbox(
+        (4.89, 52.37, 4.91, 52.38), pano_only=pano_only
+    )
+
+    assert seen.get("is_pano") == ("true" if pano_only else None)
 
 
 def test_model_matches_db_schema():

--- a/tests/test_panoramax_client.py
+++ b/tests/test_panoramax_client.py
@@ -83,6 +83,59 @@ def test_fetch_queries_the_bbox_as_given(fake_panoramax_client, spy_request):
     assert spy_request["bbox"] == "2.336698,48.865696,2.346236,48.87065"
 
 
+def test_pano_only_filters_in_the_federated_catalogue(
+    fake_panoramax_client, spy_request
+):
+    """The catalogue filters on the field of view, so the limit counts panoramas."""
+    fake_panoramax_client.fetch_metadata_bbox(
+        (2.34, 48.85, 2.35, 48.86), pano_only=True
+    )
+
+    assert spy_request["filter"] == "field_of_view=360"
+
+
+@pytest.mark.parametrize(
+    ("instance", "pano_only"),
+    [
+        (FEDERATED_CATALOGUE, False),
+        # A single instance rejects the filter as unsupported.
+        ("https://panoramax.openstreetmap.fr", True),
+    ],
+)
+def test_pano_only_sends_no_filter(spy_request, instance, pano_only):
+    PanoramaxClient(instance).fetch_metadata_bbox(
+        (2.34, 48.85, 2.35, 48.86), pano_only=pano_only
+    )
+
+    assert "filter" not in spy_request
+
+
+@pytest.mark.parametrize("instance", [FEDERATED_CATALOGUE, "https://example.com"])
+def test_pano_only_drops_narrow_pictures(panoramax_item, monkeypatch, instance):
+    """Whether or not the API could filter, only panoramas are returned."""
+    narrow = {
+        **panoramax_item,
+        "id": "narrow",
+        "properties": {
+            **panoramax_item["properties"],
+            "pers:interior_orientation": {"field_of_view": 95},
+        },
+    }
+    unknown = {**panoramax_item, "id": "unknown", "properties": {}}
+    monkeypatch.setattr(
+        PanoramaxClient,
+        "_request",
+        lambda self, params: {"features": [panoramax_item, narrow, unknown]},
+    )
+    client = PanoramaxClient(instance)
+    bbox = (2.34, 48.85, 2.35, 48.86)
+
+    assert list(client.fetch_metadata_bbox(bbox, pano_only=True)["id"]) == [
+        panoramax_item["id"]
+    ]
+    assert len(client.fetch_metadata_bbox(bbox)) == 3
+
+
 def test_model_matches_db_schema():
     """The model and the `panoramax` table must not drift apart."""
     schema = Project.core_tables["panoramax"]["schema"]


### PR DESCRIPTION
For facade analysis panoramic images might be more useful, as they show facades at both sides of the road. Normal images can mostly show the street surface and vehicles, while buildings are on the edges of the image.

This PR allows users to filter for pano-only images when fetching img metadata. This will reduce the images to (wastefully) download and segment.